### PR TITLE
Redesign layout for desktop view

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -48,77 +48,41 @@
 .sidebar {
   position: relative;
   background: rgba(255, 255, 255, 0.95);
-  width: 60px;
-  transition: width 0.3s ease;
+  width: 300px;
   box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
-  overflow: hidden;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 }
 
-.sidebar.show {
-  width: 320px;
-}
-
-.toggle-history {
-  width: 100%;
-  padding: 1rem;
-  background: #667eea;
+.sidebar-header {
+  padding: 1.5rem;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
-  border: none;
-  cursor: pointer;
-  font-size: 1rem;
-  font-weight: 600;
-  transition: background 0.3s;
-  white-space: nowrap;
+  text-align: center;
 }
 
-.toggle-history:hover {
-  background: #764ba2;
+.sidebar-header h3 {
+  margin: 0;
+  font-size: 1.3rem;
 }
 
 /* Main Content */
 .main-content {
   flex: 1;
-  padding: 2rem;
+  padding: 1.5rem;
   overflow-y: auto;
-}
-
-/* View Tabs */
-.view-tabs {
   display: flex;
+  flex-direction: column;
   gap: 1rem;
-  margin-bottom: 1.5rem;
-}
-
-.view-tabs button {
-  flex: 1;
-  padding: 1rem 2rem;
-  background: rgba(255, 255, 255, 0.9);
-  border: 2px solid transparent;
-  border-radius: 12px;
-  font-size: 1.1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s;
-}
-
-.view-tabs button:hover {
-  background: white;
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-}
-
-.view-tabs button.active {
-  background: white;
-  border-color: #667eea;
-  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.2);
 }
 
 /* Action Buttons */
 .action-buttons {
   display: flex;
   gap: 1rem;
-  margin-bottom: 1.5rem;
   justify-content: flex-end;
+  flex-shrink: 0;
 }
 
 .action-button {
@@ -152,19 +116,61 @@
   cursor: not-allowed;
 }
 
-/* Content Area */
-.content-area {
+/* Desktop Grid Layout */
+.desktop-grid {
+  display: grid;
+  grid-template-columns: 1fr 500px;
+  gap: 1.5rem;
+  flex: 1;
+  overflow: hidden;
+}
+
+.left-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.right-column {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.section-card {
   background: rgba(255, 255, 255, 0.95);
   border-radius: 16px;
-  padding: 2rem;
-  min-height: 500px;
+  padding: 1.5rem;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
 }
 
-/* Skin Generator */
-.skin-generator h2 {
-  margin-top: 0;
+.section-card h2 {
+  margin: 0 0 1rem 0;
   color: #333;
+  font-size: 1.4rem;
+  border-bottom: 2px solid #667eea;
+  padding-bottom: 0.5rem;
+}
+
+.generator-section,
+.editor-section {
+  flex-shrink: 0;
+}
+
+.preview-section {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Skin Generator */
+.skin-generator {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .prompt-input-section {
@@ -349,66 +355,40 @@
 }
 
 /* Preview View */
-.preview-view {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2rem;
-}
-
 .preview-container {
   display: flex;
   justify-content: center;
+  align-items: center;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  border-radius: 16px;
-  padding: 2rem;
+  border-radius: 12px;
+  padding: 1.5rem;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  margin-bottom: 1rem;
 }
 
 .preview-info {
-  text-align: center;
-  max-width: 600px;
+  text-align: left;
 }
 
 .preview-info h3 {
-  font-size: 1.8rem;
+  font-size: 1.4rem;
   color: #333;
-  margin-bottom: 1rem;
+  margin: 0 0 0.75rem 0;
+  font-weight: 600;
 }
 
 .skin-prompt {
   background: #f8f9fa;
-  padding: 1rem;
-  border-radius: 8px;
-  margin-bottom: 1rem;
-  text-align: left;
+  padding: 0.75rem;
+  border-radius: 6px;
+  margin-bottom: 0.75rem;
+  font-size: 0.9rem;
 }
 
 .skin-date {
   color: #666;
-  font-size: 0.9rem;
-  margin-bottom: 1rem;
-}
-
-.preview-actions {
-  margin-top: 1.5rem;
-}
-
-.edit-button {
-  padding: 1rem 2rem;
-  background: #667eea;
-  color: white;
-  border: none;
-  border-radius: 8px;
-  font-size: 1.1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s;
-}
-
-.edit-button:hover {
-  background: #764ba2;
-  transform: translateY(-2px);
+  font-size: 0.85rem;
+  margin: 0;
 }
 
 /* History Panel */
@@ -578,13 +558,42 @@
 }
 
 /* Responsive Design */
+@media (max-width: 1200px) {
+  .desktop-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .right-column {
+    order: -1;
+  }
+}
+
 @media (max-width: 768px) {
   .app-header h1 {
     font-size: 1.8rem;
   }
 
-  .view-tabs {
+  .app-header p {
+    font-size: 0.95rem;
+  }
+
+  .app-container {
     flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    max-height: 300px;
+    border-bottom: 2px solid #667eea;
+  }
+
+  .main-content {
+    padding: 1rem;
+  }
+
+  .desktop-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
   }
 
   .action-buttons {
@@ -595,13 +604,15 @@
     flex-direction: column;
   }
 
-  .sidebar.show {
-    position: absolute;
-    z-index: 100;
-    height: 100%;
-  }
-
   .preview-container {
     padding: 1rem;
+  }
+
+  .section-card {
+    padding: 1rem;
+  }
+
+  .section-card h2 {
+    font-size: 1.2rem;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,12 +8,8 @@ import { skinStorage } from './utils/skinStorage';
 import { exportSkinAsPNG, createBlankSkin } from './utils/skinExport';
 import './App.css';
 
-type ViewMode = 'generator' | 'editor' | 'preview';
-
 function App() {
   const [currentSkin, setCurrentSkin] = useState<MinecraftSkin | null>(null);
-  const [viewMode, setViewMode] = useState<ViewMode>('generator');
-  const [showHistory, setShowHistory] = useState(false);
 
   // Initialize with a blank skin
   useEffect(() => {
@@ -37,7 +33,6 @@ function App() {
 
     setCurrentSkin(newSkin);
     skinStorage.saveSkin(newSkin);
-    setViewMode('preview');
   }, []);
 
   const handleSkinChange = useCallback((newSkinData: string) => {
@@ -60,7 +55,6 @@ function App() {
 
     if (skin) {
       setCurrentSkin(skin);
-      setViewMode('preview');
     }
   }, []);
 
@@ -81,7 +75,6 @@ function App() {
     };
 
     setCurrentSkin(newSkin);
-    setViewMode('editor');
   }, []);
 
   return (
@@ -92,46 +85,19 @@ function App() {
       </header>
 
       <div className="app-container">
-        {/* Sidebar */}
-        <aside className={`sidebar ${showHistory ? 'show' : ''}`}>
-          <button
-            className="toggle-history"
-            onClick={() => setShowHistory(!showHistory)}
-          >
-            {showHistory ? '◀' : '▶'} 히스토리
-          </button>
-          {showHistory && (
-            <HistoryPanel
-              onSkinSelect={handleSkinSelect}
-              currentSkinId={currentSkin?.id}
-            />
-          )}
+        {/* Left Sidebar - History Panel */}
+        <aside className="sidebar">
+          <div className="sidebar-header">
+            <h3>📚 히스토리</h3>
+          </div>
+          <HistoryPanel
+            onSkinSelect={handleSkinSelect}
+            currentSkinId={currentSkin?.id}
+          />
         </aside>
 
-        {/* Main Content */}
+        {/* Main Content Area */}
         <main className="main-content">
-          {/* View Mode Tabs */}
-          <div className="view-tabs">
-            <button
-              className={viewMode === 'generator' ? 'active' : ''}
-              onClick={() => setViewMode('generator')}
-            >
-              🤖 AI 생성
-            </button>
-            <button
-              className={viewMode === 'editor' ? 'active' : ''}
-              onClick={() => setViewMode('editor')}
-            >
-              ✏️ 에디터
-            </button>
-            <button
-              className={viewMode === 'preview' ? 'active' : ''}
-              onClick={() => setViewMode('preview')}
-            >
-              👀 3D 프리뷰
-            </button>
-          </div>
-
           {/* Action Buttons */}
           <div className="action-buttons">
             <button onClick={handleNewSkin} className="action-button">
@@ -146,50 +112,56 @@ function App() {
             </button>
           </div>
 
-          {/* Content Area */}
-          <div className="content-area">
-            {viewMode === 'generator' && (
-              <SkinGenerator onSkinGenerated={handleSkinGenerated} />
-            )}
-
-            {viewMode === 'editor' && currentSkin && (
-              <div className="editor-view">
-                <SkinEditor
-                  skinData={currentSkin.imageData}
-                  onSkinChange={handleSkinChange}
-                  scale={8}
-                />
+          {/* Grid Layout for Components */}
+          <div className="desktop-grid">
+            {/* Left Column: Generator and Editor */}
+            <div className="left-column">
+              {/* AI Generator */}
+              <div className="generator-section section-card">
+                <h2>🤖 AI 스킨 생성</h2>
+                <SkinGenerator onSkinGenerated={handleSkinGenerated} />
               </div>
-            )}
 
-            {viewMode === 'preview' && currentSkin && (
-              <div className="preview-view">
-                <div className="preview-container">
-                  <SkinViewer3D
+              {/* Editor */}
+              {currentSkin && (
+                <div className="editor-section section-card">
+                  <h2>✏️ 스킨 에디터</h2>
+                  <SkinEditor
                     skinData={currentSkin.imageData}
-                    width={600}
-                    height={600}
-                    autoRotate={true}
+                    onSkinChange={handleSkinChange}
+                    scale={6}
                   />
                 </div>
-                <div className="preview-info">
-                  <h3>{currentSkin.name}</h3>
-                  {currentSkin.prompt && (
-                    <p className="skin-prompt">
-                      <strong>프롬프트:</strong> {currentSkin.prompt}
+              )}
+            </div>
+
+            {/* Right Column: 3D Preview */}
+            <div className="right-column">
+              {currentSkin && (
+                <div className="preview-section section-card">
+                  <h2>👀 3D 프리뷰</h2>
+                  <div className="preview-container">
+                    <SkinViewer3D
+                      skinData={currentSkin.imageData}
+                      width={450}
+                      height={450}
+                      autoRotate={true}
+                    />
+                  </div>
+                  <div className="preview-info">
+                    <h3>{currentSkin.name}</h3>
+                    {currentSkin.prompt && (
+                      <p className="skin-prompt">
+                        <strong>프롬프트:</strong> {currentSkin.prompt}
+                      </p>
+                    )}
+                    <p className="skin-date">
+                      생성일: {new Date(currentSkin.createdAt).toLocaleString('ko-KR')}
                     </p>
-                  )}
-                  <p className="skin-date">
-                    생성일: {new Date(currentSkin.createdAt).toLocaleString('ko-KR')}
-                  </p>
-                  <div className="preview-actions">
-                    <button onClick={() => setViewMode('editor')} className="edit-button">
-                      ✏️ 편집하기
-                    </button>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
+            </div>
           </div>
         </main>
       </div>

--- a/src/components/SkinGenerator.tsx
+++ b/src/components/SkinGenerator.tsx
@@ -51,8 +51,6 @@ export function SkinGenerator({ onSkinGenerated }: SkinGeneratorProps) {
 
   return (
     <div className="skin-generator">
-      <h2>AI 스킨 생성</h2>
-
       <div className="prompt-input-section">
         <textarea
           value={prompt}


### PR DESCRIPTION
- 탭 형태 제거하고 모든 컴포넌트를 한 화면에 배치
- 왼쪽: 히스토리 패널 (항상 표시)
- 중앙: AI 생성기 + 에디터 (세로로 배치)
- 오른쪽: 3D 프리뷰
- 그리드 레이아웃으로 데스크톱에 최적화
- 반응형 디자인 개선 (모바일에서는 1열로 표시)